### PR TITLE
Update to nite-owl 2.0.0 and use default debounce value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports = (rootDir, config = "faucet.js", // eslint-disable-next-line ind
 	let configDir = path.dirname(configPath);
 	config = require(configPath);
 
-	let watcher = watch && makeWatcher(rootDir, 100); // XXX: magic number; configurable?
+	let watcher = watch && makeWatcher(rootDir);
 
 	Object.keys(PLUGINS).forEach(type => {
 		let cfg = config[type];

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "minimist": "^1.2.0",
-    "nite-owl": "^1.0.0"
+    "nite-owl": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^4.0.0",


### PR DESCRIPTION
The new default debounce value is 50. We determined by a fair dice role that this is a better magic number.